### PR TITLE
Specify Ruby version to 2.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source 'https://rubygems.org'
 
+ruby '2.3.0'
+
 gem 'sinatra'
 gem 'activesupport'


### PR DESCRIPTION
バージョン指定していなかったので、Heroku 上でEOL(end-of-life) を迎える`2.0.0` が利用されていた
バージョン番号を指定して、対処する
